### PR TITLE
Add logout function

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+
+  helper_method :logged_in?
+
+  private
+
+  def logged_in?
+    !!session[:user_id]
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
-
   helper_method :logged_in?
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,4 +4,9 @@ class SessionsController < ApplicationController
     session[:user_id] = user.id
     redirect_to root_path, notice: 'ログインしました'
   end
+
+  def destroy
+    reset_session
+    redirect_to root_path, notice: 'ログアウトしました'
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    reset_session
+    session.delete(:user_id)
     redirect_to root_path, notice: 'ログアウトしました'
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,11 @@
           <%= link_to 'AwesomeEvents', root_path, class: 'navbar-brand' %>
         </div>        
         <ul class='nav navbar-nacv navbar-right'>
-          <li><%= link_to 'Twitterでログイン', '/auth/twitter' %></li>
+          <% if logged_in? %>
+            <li><%= link_to 'ログアウト', logout_path %></li>
+          <% else %>
+            <li><%= link_to 'Twitterでログイン', '/auth/twitter' %></li>
+          <% end %>
         </ul>
       </div>
     </header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   root 'welcome#index'
   get '/auth/:provider/callback' => 'sessions#create'
+  get '/logout' => 'sessions#destroy', as: :logout
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,19 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe SessionsController, type: :request do
+  before do
+    OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new(
+      provider: 'twitter',
+      uid: '0123456789',
+      info: {
+        nickname: 'hogehoge',
+        image: 'http://image.example.com',
+      },
+    )
+  end
+
   describe '#create' do
     subject { get '/auth/twitter/callback' }
-
-    before do
-      OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new(
-        provider: 'twitter',
-        uid: '0123456789',
-        info: {
-          nickname: 'hogehoge',
-          image: 'http://image.example.com',
-        },
-      )
-    end
 
     context 'ユーザが未登録の場合' do
       it 'ユーザを新規作成すること' do

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -51,4 +51,16 @@ RSpec.describe SessionsController, type: :request do
       end
     end
   end
+
+  describe '#destroy' do
+    before { get '/logout' }
+
+    it 'sessionがリセットされていること' do
+      expect(session[:user_id]).to be_nil
+    end
+
+    it 'ログアウト後トップページにリダイレクトすること' do
+      expect(response).to redirect_to root_path
+    end
+  end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -53,7 +53,10 @@ RSpec.describe SessionsController, type: :request do
   end
 
   describe '#destroy' do
-    before { get '/logout' }
+    before do
+      get '/auth/twitter/callback'
+      get '/logout'
+    end
 
     it 'sessionがリセットされていること' do
       expect(session[:user_id]).to be_nil

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -53,16 +53,17 @@ RSpec.describe SessionsController, type: :request do
   end
 
   describe '#destroy' do
-    before do
-      get '/auth/twitter/callback'
-      get '/logout'
-    end
+    subject { get '/logout' }
+
+    before { get '/auth/twitter/callback' }
 
     it 'sessionがリセットされていること' do
+      subject
       expect(session[:user_id]).to be_nil
     end
 
     it 'ログアウト後トップページにリダイレクトすること' do
+      subject
       expect(response).to redirect_to root_path
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,16 +81,16 @@ RSpec.configure do |config|
   # particularly slow.
   config.profile_examples = 10
 
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
 end


### PR DESCRIPTION
やったこと
---

-  OAuthを利用したTwitterログイン機能に、ログアウト機能を追加
   - `SessionsController#create`の作成
   - ログアウト時は「Twitterでログイン」、ログイン時は「ログアウト」、とリンクが切り替わるようにトップページを編集。
   - ユーザーがログイン状態かどうかを確かめるための、`logged_in?`メソッドをヘルパーメソッドとして定義。
   - `routes.rb`ファイルに、ログアウトするルーティングを追記
   - `SessionsController#destroy`のRequest Specを作成


動作確認方法
---

- `$ bundle exec rails s`の実行
- `lvh.me:3000`にアクセス
- ヘッダーの「Twitterでログイン」リンクからページ遷移し、'連携アプリを認証'ボタンをクリック
- ヘッダーの「ログアウト」リンクによりログアウトを実行
- 下記ページが表示されることを確認
<img width="1024" alt="default" src="https://user-images.githubusercontent.com/34771978/40416848-53ebd14c-5eb9-11e8-99c4-0b883a7af902.png">
