### PR TITLE
イベント参加機能の作成

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,6 @@
 // about supported directives.
 //
 //= require rails-ujs
-//= require_tree .
 //= require jquery
 //= require bootstrap/dist/js/bootstrap.min.js
+//= require_tree .

--- a/app/assets/javascripts/tickets.coffee
+++ b/app/assets/javascripts/tickets.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/tickets.coffee
+++ b/app/assets/javascripts/tickets.coffee
@@ -2,7 +2,6 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
-
 $(document).on 'ajax:success', '#createTicket', (data) ->
   location.reload()
 

--- a/app/assets/javascripts/tickets.coffee
+++ b/app/assets/javascripts/tickets.coffee
@@ -1,3 +1,21 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
+
+
+$(document).on 'ajax:success', '#createTicket', (data) ->
+  location.reload()
+
+$(document).on 'ajax:error', '#createTicket', (data) ->
+  form = $('#new_ticket .modal-body')
+  div = $('<div id="createTicketErrors" class="alert alert-danger"></div>')
+  ul = $('<ul></ul>')
+  data.detail[0].messages.forEach (message, i) ->
+    li = $('<li></li>').text(message)
+    ul.append(li)
+
+  if $('#createTicketErrors')[0]
+    $('#createTicketErrors').html(ul)
+  else
+    div.append(ul)
+    form.prepend(div)

--- a/app/assets/stylesheets/tickets.scss
+++ b/app/assets/stylesheets/tickets.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the tickets controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user, :logged_in?
 
-  rescue_from ActiveRecord::RecordNotFound, ActionController::RoutingError, with: :error404
+  rescue_from ActiveRecord::RecordNotFound, with: :error404
 
   private
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user, :logged_in?
 
-  rescue_from ActiveRecord::RecordNotFound, with: :error404
+  rescue_from ActiveRecord::RecordNotFound, ActionController::RoutingError, with: :error404
 
   private
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -16,6 +16,8 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.find(params[:id])
+    @ticket = @event.tickets.build
+    @tickets = @event.tickets.includes(:user).order(:created_at)
   end
 
   def edit

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -1,0 +1,2 @@
+class TicketsController < ApplicationController
+end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -1,2 +1,20 @@
 class TicketsController < ApplicationController
+  before_action :authenticate
+
+  def new
+    raise ActionController::RoutingError, 'ログイン状態で TicketsController#new にアクセス'
+  end
+
+  def create
+    ticket = current_user.tickets.build do |t|
+      t.event_id = params[:event_id]
+      t.comment = params[:ticket][:comment]
+    end
+    if ticket.save
+      flash[:notice] = 'このイベントに参加表明しました'
+      head 201
+    else
+      render json: { messages: ticket.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
 end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -1,10 +1,6 @@
 class TicketsController < ApplicationController
   before_action :authenticate
 
-  def new
-    raise ActionController::RoutingError, 'ログイン状態で TicketsController#new にアクセス'
-  end
-
   def create
     ticket = current_user.tickets.build do |t|
       t.event_id = params[:event_id]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def url_for_twitter(user)
+    "https://twitter.com/#{user.nickname}"
+  end
 end

--- a/app/helpers/tickets_helper.rb
+++ b/app/helpers/tickets_helper.rb
@@ -1,0 +1,2 @@
+module TicketsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ApplicationRecord
+  has_many :tickets
   belongs_to :owner, class_name: 'User'
 
   validates :name, length: { maximum: 50 }, presence: true

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,0 +1,4 @@
+class Ticket < ApplicationRecord
+  belongs_to :user
+  belongs_to :event
+end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,4 +1,6 @@
 class Ticket < ApplicationRecord
   belongs_to :user
   belongs_to :event
+
+  validates :comment, length: { maximum: 30 }, allow_blank: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :created_events, class_name: 'Event', foreign_key: :owner_id
+  has_many :tickets
 
   def self.find_or_create_from_auth_hash(auth_hash)
     provider = auth_hash[:provider]

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -10,7 +10,7 @@
         主催者
       </div>
       <div class='card-body'>
-        <%= link_to("https://twitter.com/#{@event.owner.nickname}") do %>
+        <%= link_to(url_for_twitter(@event.owner)) do %>
           <%= image_tag @event.owner.image_url %>
           <%= "@#{@event.owner.nickname}" %>
         <% end %>
@@ -46,5 +46,52 @@
       <%= link_to 'イベントを編集する', edit_event_path(@event), class: 'btn btn-info btn-primary' %>
       <%= link_to 'イベントを削除する', event_path(@event), class: 'btn btn-danger btn-primary', method: :delete, data: { confirm: '本当に削除しますか？' } %>
     <% end %>
+    <% if logged_in? && @event.tickets.find_by(user_id: current_user.id).nil? %>
+      <button class='btn btn-primary btn-lg btn-block' data-toggle='modal' data-target='#createTicket'>
+        参加する
+      </button>
+      <div class='modal fade' id='createTicket' tabindex='-1' role='dialog' aria-labelledby='dialogHeader' aria-hidden='true'>
+        <div class='modal-dialog'>
+          <div class='modal-content'>
+            <div class='modal-header'>
+              <button type='button' class='close' data-dismiss='modal' aria-hidden='true'>&times;</button>
+              <h4 class='modal-title' id='dialogHeader'>参加コメント</h4>
+            </div>
+            <%= form_with(model: [@event, @ticket], id: 'new_ticket') do |f| %>
+              <div class='modal-body'>
+                <%= f.text_field :comment, class: 'form-control' %>
+              </div>
+              <div class='modal-footer'>
+                <button type='button' class='btn btn-default' data-dismiss='modal'>キャンセル</button>
+                <%= f.button '送信', class: 'btn btn-primary', data: { disable_with: '送信中...' } %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% elsif logged_in? %>
+      <button class='btn btn-primary btn-lg btn-block' >参加済み</button>
+    <% else %>
+      <%= link_to '参加する', new_event_ticket_path(@event), class: 'btn btn-primary btn-lg btn-block' %>
+    <% end %>
+    <hr>
+    <div class="card mt-3">
+      <div class="card-header">
+        参加者
+      </div>
+      <div class="card-body">
+        <ul class="list-unstyled">
+          <% @tickets.each do |ticket| %>
+            <li>
+              <%= link_to(url_for_twitter(ticket.user)) do %>
+                <%= image_tag ticket.user.image_url, width: 20, height: 20 %>
+                <%= "@#{ticket.user.nickname}" %>
+              <% end %>
+              <%= ticket.comment %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -72,7 +72,7 @@
     <% elsif logged_in? %>
       <button class='btn btn-primary btn-lg btn-block' >参加済み</button>
     <% else %>
-      <%= link_to '参加する', new_event_ticket_path(@event), class: 'btn btn-primary btn-lg btn-block' %>
+      <button class='btn btn-primary btn-lg btn-block' >参加するにはログインしてください</button>
     <% end %>
     <hr>
     <div class="card mt-3">

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     models:
       event: イベント
+      ticket: チケット
     attributes:
       event:
         name: 名前
@@ -9,3 +10,5 @@ ja:
         start_time: 開始時間
         end_time: 終了時間
         content: 内容
+      ticket:
+        comment: コメント

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   resources :events do
-    resources :tickets
+    resources :tickets, only: :create
   end
   root 'welcome#index'
   get '/auth/:provider/callback' => 'sessions#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  resources :events
+  resources :events do
+    resources :tickets
+  end
   root 'welcome#index'
   get '/auth/:provider/callback' => 'sessions#create'
   get '/logout' => 'sessions#destroy', as: :logout

--- a/db/migrate/20180615022320_create_tickets.rb
+++ b/db/migrate/20180615022320_create_tickets.rb
@@ -1,0 +1,11 @@
+class CreateTickets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :tickets do |t|
+      t.references :user, foreign_key: true
+      t.references :event, foreign_key: true
+      t.string :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180615022320_create_tickets.rb
+++ b/db/migrate/20180615022320_create_tickets.rb
@@ -1,11 +1,14 @@
 class CreateTickets < ActiveRecord::Migration[5.2]
   def change
     create_table :tickets do |t|
-      t.references :user, foreign_key: true
-      t.references :event, foreign_key: true
+      t.references :user
+      t.references :event, null: false
       t.string :comment
 
       t.timestamps
     end
+
+    add_index :tickets, [:user_id, :event_id], unique: true
+    add_index :tickets, [:event_id, :user_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_25_070622) do
+ActiveRecord::Schema.define(version: 2018_06_15_022320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,18 @@ ActiveRecord::Schema.define(version: 2018_05_25_070622) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["owner_id"], name: "index_events_on_owner_id"
+  end
+
+  create_table "tickets", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "event_id", null: false
+    t.string "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id", "user_id"], name: "index_tickets_on_event_id_and_user_id", unique: true
+    t.index ["event_id"], name: "index_tickets_on_event_id"
+    t.index ["user_id", "event_id"], name: "index_tickets_on_user_id_and_event_id", unique: true
+    t.index ["user_id"], name: "index_tickets_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/controllers/tickets_controller_spec.rb
+++ b/spec/controllers/tickets_controller_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe TicketsController, type: :controller do
+end

--- a/spec/factories/tickets.rb
+++ b/spec/factories/tickets.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :ticket do
-    user nil
-    event nil
-    comment 'MyString'
+    user
+    event
+    sequence(:comment) { |i| "comment_#{i}" }
   end
 end

--- a/spec/factories/tickets.rb
+++ b/spec/factories/tickets.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :ticket do
+    user nil
+    event nil
+    comment 'MyString'
+  end
+end

--- a/spec/helpers/tickets_helper_spec.rb
+++ b/spec/helpers/tickets_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the TicketsHelper. For example:
+#
+# describe TicketsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe TicketsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Ticket, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Ticket, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#comment' do
+    it { should allow_value(nil).for(:comment) }
+    it { should validate_length_of(:comment).is_at_most(30) }
+  end
 end

--- a/spec/requests/tickets_spec.rb
+++ b/spec/requests/tickets_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+RSpec.describe 'TicketsController', type: :request do
+  let(:event) { create(:event) }
+
+  let!(:user) do
+    create(
+      :user,
+      provider: 'twitter',
+      uid: '0123456789',
+      nickname: 'hogehoge',
+      image_url: 'http://image.example.com',
+    )
+  end
+
+  before do
+    OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new(
+      provider: 'twitter',
+      uid: '0123456789',
+      info: {
+        nickname: 'hogehoge',
+        image: 'http://image.example.com',
+      },
+    )
+  end
+
+  describe '#new' do
+    context 'ログインしている場合' do
+      before { get '/auth/twitter/callback' }
+
+      it 'error.html.erb ページに遷移する' do
+        get "/events/#{event.id}/tickets/new"
+        expect(response).to render_template :error404
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it 'トップページにリダイレクトする' do
+        get "/events/#{event.id}/tickets/new"
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'ログインしている場合' do
+      before { get '/auth/twitter/callback' }
+
+      context '該当イベントにまだ参加していない場合' do
+        context 'チケット作成 のmodalで、正しい値が入力された場合' do
+          let(:params) do
+            {
+              ticket: {
+                comment: 'comment',
+              },
+            }
+          end
+
+          it 'チケットを新規作成する' do
+            expect { post "/events/#{event.id}/tickets", params: params }.to change { Ticket.count }.by(1)
+          end
+
+          it 'ステータスコード201 が返る' do
+            post "/events/#{event.id}/tickets", params: params
+            expect(response.status).to eq 201
+          end
+
+          it 'フラッシュメッセージが表示される' do
+            post "/events/#{event.id}/tickets", params: params
+            expect(flash[:notice]).to eq 'このイベントに参加表明しました'
+          end
+        end
+
+        context 'チケット作成のmodal で、comment が31文字以上だった場合' do
+          let(:params) do
+            {
+              ticket: {
+                comment: 'a' * 31,
+              },
+            }
+          end
+
+          it '新しいチケットが作成されない' do
+            expect { post "/events/#{event.id}/tickets", params: params }.not_to change { Ticket.count }
+          end
+
+          it 'ステータスコード422 が返る' do
+            post "/events/#{event.id}/tickets", params: params
+            expect(response.status).to eq 422
+          end
+        end
+      end
+
+      context '該当イベントに参加している場合' do
+        let(:params) do
+          {
+            ticket: {
+              comment: 'comment',
+            },
+          }
+        end
+
+        before { post "/events/#{event.id}/tickets", params: params }
+
+        it 'paramsで正しい値を送っても、ActiveRecord::RecordNotUniqueが発生する' do
+          expect { post "/events/#{event.id}/tickets", params: params }.to raise_error(ActiveRecord::RecordNotUnique)
+        end
+      end
+    end
+
+    context 'ログインしていない場合' do
+      let(:params) do
+        {
+          ticket: {
+            comment: 'comment',
+          },
+        }
+      end
+
+      it 'params で正しい値が送られても、新しいイベントが作成されない' do
+        expect { post "/events/#{event.id}/tickets", params: params }.not_to change { Ticket.count }
+      end
+
+      it 'トップページにリダイレクトする' do
+        post "/events/#{event.id}/tickets", params: params
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+end

--- a/spec/requests/tickets_spec.rb
+++ b/spec/requests/tickets_spec.rb
@@ -24,24 +24,6 @@ RSpec.describe 'TicketsController', type: :request do
     )
   end
 
-  describe '#new' do
-    context 'ログインしている場合' do
-      before { get '/auth/twitter/callback' }
-
-      it 'error.html.erb ページに遷移する' do
-        get "/events/#{event.id}/tickets/new"
-        expect(response).to render_template :error404
-      end
-    end
-
-    context 'ログインしていない場合' do
-      it 'トップページにリダイレクトする' do
-        get "/events/#{event.id}/tickets/new"
-        expect(response).to redirect_to root_path
-      end
-    end
-  end
-
   describe '#create' do
     context 'ログインしている場合' do
       before { get '/auth/twitter/callback' }

--- a/spec/requests/tickets_spec.rb
+++ b/spec/requests/tickets_spec.rb
@@ -30,13 +30,7 @@ RSpec.describe 'TicketsController', type: :request do
 
       context '該当イベントにまだ参加していない場合' do
         context 'チケット作成 のmodalで、正しい値が入力された場合' do
-          let(:params) do
-            {
-              ticket: {
-                comment: 'comment',
-              },
-            }
-          end
+          let(:params) { { ticket: { comment: 'comment' } } }
 
           it 'チケットを新規作成する' do
             expect { post "/events/#{event.id}/tickets", params: params }.to change { Ticket.count }.by(1)
@@ -54,13 +48,7 @@ RSpec.describe 'TicketsController', type: :request do
         end
 
         context 'チケット作成のmodal で、comment が31文字以上だった場合' do
-          let(:params) do
-            {
-              ticket: {
-                comment: 'a' * 31,
-              },
-            }
-          end
+          let(:params) { { ticket: { comment: 'a' * 31 } } }
 
           it '新しいチケットが作成されない' do
             expect { post "/events/#{event.id}/tickets", params: params }.not_to change { Ticket.count }
@@ -74,13 +62,7 @@ RSpec.describe 'TicketsController', type: :request do
       end
 
       context '該当イベントに参加している場合' do
-        let(:params) do
-          {
-            ticket: {
-              comment: 'comment',
-            },
-          }
-        end
+        let(:params) { { ticket: { comment: 'comment' } } }
 
         before { post "/events/#{event.id}/tickets", params: params }
 
@@ -91,13 +73,7 @@ RSpec.describe 'TicketsController', type: :request do
     end
 
     context 'ログインしていない場合' do
-      let(:params) do
-        {
-          ticket: {
-            comment: 'comment',
-          },
-        }
-      end
+      let(:params) { { ticket: { comment: 'comment' } } }
 
       it 'params で正しい値が送られても、新しいイベントが作成されない' do
         expect { post "/events/#{event.id}/tickets", params: params }.not_to change { Ticket.count }

--- a/spec/system/tickets_spec.rb
+++ b/spec/system/tickets_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe 'Tickets', type: :system do
+  let(:event) { create(:event) }
+
+  before do
+    OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new(
+      provider: 'twitter',
+      uid: '0123456789',
+      info: {
+        nickname: 'hogehoge',
+        image: 'http://image.example.com',
+      },
+    )
+  end
+
+  it 'ログインせずに、イベント参加を試みる' do
+    # イベントページへアクセスする
+    visit "/events/#{event.id}"
+
+    # 参加を試みても、トップページにリダイレクトする
+    click_on '参加する'
+    expect(page).to have_content 'ログインしてください'
+  end
+
+  it 'ログイン後、正しいコメントを入力し、イベント参加を行う' do
+    # ログインする
+    visit '/'
+    click_on 'Twitterでログイン'
+
+    # イベントページへアクセスする
+    visit "/events/#{event.id}"
+
+    # 参加する
+    click_on '参加する'
+    fill_in 'ticket[comment]', with: 'comment'
+    click_on '送信'
+
+    # フラッシュメッセージが表示される
+    expect(page).to have_content 'このイベントに参加表明しました'
+
+    # 参加後はイベントページの参加者欄にnickname が追加される参加ボタンが参加済みに変更されている
+    expect(page).to have_content '参加者'
+    expect(page).to have_content 'hogehoge'
+
+    # 参加ボタンが参加済みに変更されている
+    expect(page).to have_content '参加済み'
+  end
+
+  it 'ログイン後、31文字以上のコメントを入力し、イベント参加を試みる' do
+    # ログインする
+    visit '/'
+    click_on 'Twitterでログイン'
+
+    # イベントページへアクセスする
+    visit "/events/#{event.id}"
+
+    # 参加する
+    click_on '参加する'
+    fill_in 'ticket[comment]', with: 'a' * 31
+    click_on '送信'
+
+    # エラーメッセージが表示される
+    expect(page).to have_content 'コメントは30文字以内で入力してください'
+  end
+end

--- a/spec/system/tickets_spec.rb
+++ b/spec/system/tickets_spec.rb
@@ -18,9 +18,8 @@ RSpec.describe 'Tickets', type: :system do
     # イベントページへアクセスする
     visit "/events/#{event.id}"
 
-    # 参加を試みても、トップページにリダイレクトする
-    click_on '参加する'
-    expect(page).to have_content 'ログインしてください'
+    # ログインを促される
+    expect(page).to have_content '参加するにはログインしてください'
   end
 
   it 'ログイン後、正しいコメントを入力し、イベント参加を行う' do


### PR DESCRIPTION
やったこと
---

-  イベント参加機能の作成
   - `Ticket` モデルを作成し、`User` モデル、`Event` モデルとのアソシエーションを組む
   - `TicketsController` を作成
   - イベントの詳細ページに、イベント参加フォーム、イベント参加者一覧を追加
   - `ApplicationHelper` に、ビューで使用する、`url_for_twitter(user)` メソッドを作成
   - `tickets.coffee` ファイルに、イベント参加アクション発生じの動きを記載
   - ActionController::RoutingError が発生した時のエラーハンドリングを作成
   - イベント参加時のエラーメッセージを日本語化するための記載を、`activerecord.ja.yml` に追記
- `Ticket` モデルに関する Model Spec の作成。
- `TicketsController` に関するRequest Spec の作成。
- イベント参加に関する、System Spec を作成。

動作確認方法
---

- `$ bundle exec rails s`の実行
- `lvh.me:3000`にアクセス
- ヘッダーの「Twitterでログイン」リンクより、ログインを実行
- トップページよりイベントを選択し、下記、イベント参加ボタンを確認
<img width="500" alt="2018-06-15 13 44 42" src="https://user-images.githubusercontent.com/34771978/41450435-ba785192-70a2-11e8-87b9-87c6da2c0363.png">


- イベント参加ボタンをクリックすると、コメント入力フォームが表示される
<img width="500" alt="2018-06-15 13 45 02" src="https://user-images.githubusercontent.com/34771978/41450459-d8ace754-70a2-11e8-97cb-f085adaa9525.png">

- コメントを入力し、送信ボタンを押すと、参加者一覧に`nickname` が追加され、参加ボタンが参加済みに変更される。
<img width="500" alt="2018-06-15 13 45 17" src="https://user-images.githubusercontent.com/34771978/41450515-43e7c390-70a3-11e8-9246-b3eae2ac4905.png">

- 31文字以上のコメントを入力すると、エラーメッセージが表示される
<img width="500" alt="2018-06-15 13 47 00" src="https://user-images.githubusercontent.com/34771978/41450533-61713568-70a3-11e8-8459-e8d75f650f99.png">

- ログアウトした状態では、イベント参加ボタンが、ログインを促す表記に変更されている。

