### PR TITLE
イベント参加をキャンセルする機能の作成

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -13,4 +13,10 @@ class TicketsController < ApplicationController
       render json: { messages: ticket.errors.full_messages }, status: :unprocessable_entity
     end
   end
+
+  def destroy
+    ticket = current_user.tickets.find_by!(event_id: params[:event_id])
+    ticket.destroy!
+    redirect_to event_path(params[:event_id]), notice: 'このイベントの参加をキャンセルしました'
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,5 @@
 class Event < ApplicationRecord
-  has_many :tickets
+  has_many :tickets, dependent: :destroy
   belongs_to :owner, class_name: 'User'
 
   validates :name, length: { maximum: 50 }, presence: true

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -72,7 +72,7 @@
     <% elsif logged_in? %>
       <button class='btn btn-primary btn-lg btn-block' >参加済み</button>
     <% else %>
-      <button class='btn btn-primary btn-lg btn-block' >参加するにはログインしてください</button>
+      <button class='btn btn-primary btn-lg btn-block', disabled >参加するにはログインしてください</button>
     <% end %>
     <hr>
     <div class="card mt-3">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -70,7 +70,7 @@
         </div>
       </div>
     <% elsif logged_in? %>
-      <button class='btn btn-primary btn-lg btn-block' >参加済み</button>
+      <%= link_to '参加をキャンセルする', event_ticket_path(@event, @tickets.find_by(user_id: current_user.id)), method: :delete, class: 'btn btn-warning btn-lg btn-block' %>
     <% else %>
       <button class='btn btn-primary btn-lg btn-block', disabled >参加するにはログインしてください</button>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   resources :events do
-    resources :tickets, only: :create
+    resources :tickets, only: [:create, :destroy]
   end
   root 'welcome#index'
   get '/auth/:provider/callback' => 'sessions#create'

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe 'EventsController', type: :request do
       context '対象のイベントを、ログインユーザー以外のユーザーが作成している場合' do
         let(:event) { create(:event) }
 
-        it 'ActiveRecord::RecordNotFound が発生し、error.html.erb ページに遷移する' do
+        it '404 ページに遷移する' do
           get "/events/#{event.id}/edit"
           expect(response).to render_template :error404
         end
@@ -249,7 +249,7 @@ RSpec.describe 'EventsController', type: :request do
           expect { patch "/events/#{event.id}/", params: params }.not_to change { Event.find(event.id).name }
         end
 
-        it 'ActiveRecord::RecordNotFound が発生し、error.html.erb ページに遷移する' do
+        it '404 ページに遷移する' do
           get "/events/#{event.id}/edit"
           expect(response).to render_template :error404
         end
@@ -308,7 +308,7 @@ RSpec.describe 'EventsController', type: :request do
           expect { delete "/events/#{event.id}" }.not_to change { Event.count }
         end
 
-        it 'ActiveRecord::RecordNotFound が発生し、error.html.erb ページに遷移する' do
+        it '404 ページに遷移する' do
           delete "/events/#{event.id}"
           expect(response).to render_template :error404
         end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe 'EventsController', type: :request do
       context '対象のイベントを、ログインユーザー以外のユーザーが作成している場合' do
         let(:event) { create(:event) }
 
-        it 'error.html.erb ページに遷移する' do
+        it 'ActiveRecord::RecordNotFound が発生し、error.html.erb ページに遷移する' do
           get "/events/#{event.id}/edit"
           expect(response).to render_template :error404
         end
@@ -249,7 +249,7 @@ RSpec.describe 'EventsController', type: :request do
           expect { patch "/events/#{event.id}/", params: params }.not_to change { Event.find(event.id).name }
         end
 
-        it 'error.html.erb ページに遷移する' do
+        it 'ActiveRecord::RecordNotFound が発生し、error.html.erb ページに遷移する' do
           get "/events/#{event.id}/edit"
           expect(response).to render_template :error404
         end
@@ -308,7 +308,7 @@ RSpec.describe 'EventsController', type: :request do
           expect { delete "/events/#{event.id}" }.not_to change { Event.count }
         end
 
-        it 'error.html.erb ページに遷移する' do
+        it 'ActiveRecord::RecordNotFound が発生し、error.html.erb ページに遷移する' do
           delete "/events/#{event.id}"
           expect(response).to render_template :error404
         end

--- a/spec/requests/tickets_spec.rb
+++ b/spec/requests/tickets_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'TicketsController', type: :request do
           expect { delete "/events/#{event.id}" }.not_to change { Event.count }
         end
 
-        it 'error.html.erb ページに遷移する' do
+        it 'ActiveRecord::RecordNotFound が発生し、error.html.erb ページに遷移する' do
           delete "/events/#{event.id}"
           expect(response).to render_template :error404
         end

--- a/spec/requests/tickets_spec.rb
+++ b/spec/requests/tickets_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'TicketsController', type: :request do
           expect { delete "/events/#{event.id}" }.not_to change { Event.count }
         end
 
-        it 'ActiveRecord::RecordNotFound が発生し、error.html.erb ページに遷移する' do
+        it '404 ページに遷移する' do
           delete "/events/#{event.id}"
           expect(response).to render_template :error404
         end

--- a/spec/system/tickets_spec.rb
+++ b/spec/system/tickets_spec.rb
@@ -42,8 +42,14 @@ RSpec.describe 'Tickets', type: :system do
     expect(page).to have_content '参加者'
     expect(page).to have_content 'hogehoge'
 
-    # 参加ボタンが参加済みに変更されている
-    expect(page).to have_content '参加済み'
+    # 参加をキャンセルする
+    click_on '参加をキャンセルする'
+
+    # フラッシュメッセージが表示される
+    expect(page).to have_content 'このイベントの参加をキャンセルしました'
+
+    # キャンセル後は再び参加するボタンが表示される
+    expect(page).to have_content '参加する'
   end
 
   it 'ログイン後、31文字以上のコメントを入力し、イベント参加を試みる' do


### PR DESCRIPTION
やったこと
---

-  イベント参加をキャンセルする機能の作成
   - `TicketsController#destroy` を作成
   - `Event` レコードが削除されると、該当の`Ticket` レコードが削除されるように設定
   - 'イベント参加済み'ボタンを、'イベントをキャンセルする'ボタンにビューを変更
- `TicketsController#destroy` に関するRequest Spec の作成。
- イベント参加のキャンセルに関する、System Spec を作成。

動作確認方法
---

- `$ bundle exec rails s`の実行
- `lvh.me:3000`にアクセス
- ヘッダーの「Twitterでログイン」リンクより、ログインを実行
- トップページより、既に参加表明しているイベントを選択
- 下記、'参加をキャンセルする'ボタンを確認
<img width="1249" alt="2018-06-18 17 02 43" src="https://user-images.githubusercontent.com/34771978/41525307-7ef4f186-731b-11e8-9ad5-e3bc2deaf539.png">



- イベントキャンセルボタンをクリックすると、イベント詳細ページにリダイレクトする
<img width="1257" alt="2018-06-18 17 03 18" src="https://user-images.githubusercontent.com/34771978/41525337-9e09ff26-731b-11e8-8fa4-b0b1af6cca4e.png">

